### PR TITLE
Allow auth header to be passed and allow query in uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Usage of ./vape:
     	The full path to the Vape configuration file (default "Vapefile")
   -skip-ssl-verification
     	Ignore bad SSL certs
+  -authorization string
+      Authorization header containing authentication credentials (e.g., "Bearer 123")
 ```
 
 For example:

--- a/http.go
+++ b/http.go
@@ -8,7 +8,6 @@ import (
 
 // HTTPClient is a custom interface that wraps the basic Get method.
 type HTTPClient interface {
-	Get(url string) (*http.Response, error)
 	Do(req *http.Request) (*http.Response, error)
 }
 

--- a/http.go
+++ b/http.go
@@ -9,6 +9,7 @@ import (
 // HTTPClient is a custom interface that wraps the basic Get method.
 type HTTPClient interface {
 	Get(url string) (*http.Response, error)
+	Do(req *http.Request) (*http.Response, error)
 }
 
 // NewHTTPClient returns a configrued HTTP client.

--- a/main.go
+++ b/main.go
@@ -8,10 +8,11 @@ import (
 )
 
 var (
-	vapeFile    = flag.String("config", "Vapefile", "The full path to the Vape configuration file")
-	insecureSSL = flag.Bool("skip-ssl-verification", false, "Ignore bad SSL certs")
-	concurrency = flag.Int("concurrency", 3, "The maximum number of requests to make at a time")
-	start       = time.Now()
+	vapeFile      = flag.String("config", "Vapefile", "The full path to the Vape configuration file")
+	insecureSSL   = flag.Bool("skip-ssl-verification", false, "Ignore bad SSL certs")
+	concurrency   = flag.Int("concurrency", 3, "The maximum number of requests to make at a time")
+	authorization = flag.String("authorization", "", "Authorization header containing authentication credentials")
+	start         = time.Now()
 )
 
 func main() {
@@ -36,7 +37,7 @@ func main() {
 	}
 
 	httpClient := NewHTTPClient(*insecureSSL)
-	vape := NewVape(httpClient, baseURL, *concurrency)
+	vape := NewVape(httpClient, baseURL, *concurrency, *authorization)
 
 	results, errors := vape.Process(smokeTests)
 

--- a/vape.go
+++ b/vape.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"net/http"
 )
 
 // SmokeTest contains a URI and expected status code.
@@ -62,17 +63,19 @@ type SmokeTests []SmokeTest
 
 // Vape contains dependencies used to run the application.
 type Vape struct {
-	client      HTTPClient
-	baseURL     *url.URL
-	concurrency int
+	client        HTTPClient
+	baseURL       *url.URL
+	concurrency   int
+	authorization string
 }
 
 // NewVape builds a Vape from the given dependencies.
-func NewVape(client HTTPClient, baseURL *url.URL, concurrency int) Vape {
+func NewVape(client HTTPClient, baseURL *url.URL, concurrency int, authorization string) Vape {
 	return Vape{
 		client:      client,
 		baseURL:     baseURL,
 		concurrency: concurrency,
+		authorization: authorization,
 	}
 }
 
@@ -127,9 +130,24 @@ func (v Vape) Process(tests SmokeTests) (results SmokeTestResults, errors []erro
 // performTest tests the status code of a HTTP request of a given URI.
 func (v Vape) performTest(test SmokeTest) (SmokeTestResult, error) {
 	url := *v.baseURL
-	url.Path = path.Join(url.Path, test.URI)
+	u, err := url.Parse(path.Join(url.Path + test.URI))
 
-	resp, err := v.client.Get(url.String())
+	if err != nil {
+		return SmokeTestResult{}, err
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+
+	if err != nil {
+		return SmokeTestResult{}, err
+	}
+
+	if v.authorization != "" {
+		req.Header.Add("Authorization", v.authorization)
+	}
+
+	resp, err := v.client.Do(req)
+
 	if err != nil {
 		return SmokeTestResult{}, err
 	}

--- a/vape.go
+++ b/vape.go
@@ -131,13 +131,11 @@ func (v Vape) Process(tests SmokeTests) (results SmokeTestResults, errors []erro
 func (v Vape) performTest(test SmokeTest) (SmokeTestResult, error) {
 	url := *v.baseURL
 	u, err := url.Parse(path.Join(url.Path + test.URI))
-
 	if err != nil {
 		return SmokeTestResult{}, err
 	}
 
 	req, err := http.NewRequest("GET", u.String(), nil)
-
 	if err != nil {
 		return SmokeTestResult{}, err
 	}
@@ -147,7 +145,6 @@ func (v Vape) performTest(test SmokeTest) (SmokeTestResult, error) {
 	}
 
 	resp, err := v.client.Do(req)
-
 	if err != nil {
 		return SmokeTestResult{}, err
 	}

--- a/vape_test.go
+++ b/vape_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 type mockHTTPClient struct {
-	GetFunc func(url string) (*http.Response, error)
+	DoFunc func(req *http.Request) (*http.Response, error)
 }
 
-func (m mockHTTPClient) Get(url string) (*http.Response, error) {
-	return m.GetFunc(url)
+func (m mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
 }
 
 var httpClient = new(mockHTTPClient)
@@ -144,14 +144,14 @@ func getVapeClient() Vape {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return NewVape(httpClient, baseURL, 3)
+	return NewVape(httpClient, baseURL, 3, "")
 }
 
 func TestPerformTest(t *testing.T) {
 	vape := getVapeClient()
 
 	t.Run("TestHTTPGetError", func(t *testing.T) {
-		httpClient.GetFunc = func(url string) (*http.Response, error) {
+		httpClient.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("HTTP error")
 		}
 
@@ -162,7 +162,7 @@ func TestPerformTest(t *testing.T) {
 	})
 
 	t.Run("TestHTTPGetSuccess", func(t *testing.T) {
-		httpClient.GetFunc = func(url string) (*http.Response, error) {
+		httpClient.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
 			}, nil
@@ -178,7 +178,7 @@ func TestPerformTest(t *testing.T) {
 	})
 
 	t.Run("TestHttpGetSuccessWithMatchingContent", func(t *testing.T) {
-		httpClient.GetFunc = func(url string) (*http.Response, error) {
+		httpClient.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(bytes.NewBufferString("Hello World")),
@@ -208,7 +208,7 @@ func TestPerformTest(t *testing.T) {
 	})
 
 	t.Run("TestHttpGetSuccessWithNonMatchingContent", func(t *testing.T) {
-		httpClient.GetFunc = func(url string) (*http.Response, error) {
+		httpClient.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: 200,
 				Body:       ioutil.NopCloser(bytes.NewBufferString("Not the message you are looking for")),
@@ -259,7 +259,7 @@ func TestWorker(t *testing.T) {
 	})
 	t.Run("TestProcessErrors", func(t *testing.T) {
 		vape := getVapeClient()
-		httpClient.GetFunc = func(url string) (*http.Response, error) {
+		httpClient.DoFunc = func(req *http.Request) (*http.Response, error) {
 			return nil, errors.New("HTTP error")
 		}
 

--- a/vape_test.go
+++ b/vape_test.go
@@ -144,7 +144,7 @@ func getVapeClient() Vape {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return NewVape(httpClient, baseURL, 3, "")
+	return NewVape(httpClient, baseURL, 3, "Bearer 123")
 }
 
 func TestPerformTest(t *testing.T) {


### PR DESCRIPTION
- Allows auth header to be passed in as an argument (e.g., --authorization "Bearer 123")
- Allows query parameters in the url - they were being escaped before and became part of the path, so couldn't test endpoints that needed query parameters passing to them